### PR TITLE
Allow user to control lifetime of uploaded data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The callback can receive additional data through a void pointer passed to the `u
 
 void handle_upload_file(std::string const &filename, std::string const &mime_type, emscripten_browser_file::buffer_unique_ptr &&buffer, size_t buffer_size, void *callback_data) {
   // define a handler to process the file
-  auto my_data{*reintrepret_cast<std::string*>(my_data)};
+  auto &my_data = *reintrepret_cast<std::string*>(callback_data);
   std::cout << "Received callback data: " << my_data << std::endl;
 }
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ From the user's point of view, the `upload` function acts as if the user is uplo
 ```cpp
 #include <emscripten_browser_file.h>
 
-void handle_upload_file(std::string const &filename, std::string const &mime_type, std::string_view buffer, void*) {
+void handle_upload_file(std::string const &filename, std::string const &mime_type, emscripten_browser_file::buffer_unique_ptr &&buffer, size_t buffer_size, void*) {
   // define a handler to process the file
   // ...
 }
@@ -84,7 +84,8 @@ The callback must have the following signature:
   void handle_upload_file(
     std::string const &filename,  // the filename of the file the user selected
     std::string const &mime_type, // the MIME type of the file the user selected, for example "image/png"
-    std::string_view buffer,      // the file's content is exposed in this string_view - access the data with buffer.data() and size with buffer.size().
+    buffer_unique_ptr &&buffer,   // the file's content, exposed as a buffer of 'char's
+    size_t buffer_size,           // the total number of bytes in the file
     void *callback_data = nullptr // optional callback data - identical to whatever you passed to handle_upload_file()
   );
 ```
@@ -97,7 +98,7 @@ The callback can receive additional data through a void pointer passed to the `u
 #include <emscripten_browser_file.h>
 #include <iostream>
 
-void handle_upload_file(std::string const &filename, std::string const &mime_type, std::string_view buffer, void *callback_data) {
+void handle_upload_file(std::string const &filename, std::string const &mime_type, emscripten_browser_file::buffer_unique_ptr &&buffer, size_t buffer_size, void *callback_data) {
   // define a handler to process the file
   auto my_data{*reintrepret_cast<std::string*>(my_data)};
   std::cout << "Received callback data: " << my_data << std::endl;

--- a/emscripten_browser_file.h
+++ b/emscripten_browser_file.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <string_view>
 #include <emscripten.h>
@@ -18,7 +19,15 @@ namespace emscripten_browser_file {
 
 /////////////////////////////////// Interface //////////////////////////////////
 
-using upload_handler = void(*)(std::string const&, std::string const&, std::string_view buffer, void*);
+struct buffer_deleter
+{
+	// Apparently, using C++'s 'free' on a buffer allocated with JavaScript's 'Module["_malloc"]' is safe:
+	// https://stackoverflow.com/questions/34050275/emscripten-malloc-and-free-across-js-and-c
+	void operator()(char* const pointer) { std::free(pointer); }
+};
+
+using buffer_unique_ptr = std::unique_ptr<char, buffer_deleter>;
+using upload_handler = void(*)(std::string const&, std::string const&, buffer_unique_ptr &&buffer, size_t buffer_size, void*);
 
 inline void upload(std::string const &accept_types, upload_handler callback, void *callback_data = nullptr);
 inline void download(std::string const &filename, std::string const &mime_type, std::string_view buffer);
@@ -40,7 +49,7 @@ EM_JS_INLINE(void, upload, (char const *accept_types, upload_handler callback, v
       const data_on_heap = new Uint8Array(Module["HEAPU8"].buffer, data_ptr, uint8Arr.length);
       data_on_heap.set(uint8Arr);
       Module["ccall"]('upload_file_return', 'number', ['string', 'string', 'number', 'number', 'number', 'number'], [event.target.filename, event.target.mime_type, data_on_heap.byteOffset, uint8Arr.length, callback, callback_data]);
-      Module["_free"](data_ptr);
+      //Module["_free"](data_ptr); // Freeing is handled by the buffer_unique_ptr class.
     };
     file_reader.filename = e.target.files[0].name;
     file_reader.mime_type = e.target.files[0].type;
@@ -108,18 +117,7 @@ EMSCRIPTEN_KEEPALIVE inline int upload_file_return(char const *filename, char co
 
 EMSCRIPTEN_KEEPALIVE inline int upload_file_return(char const *filename, char const *mime_type, char *buffer, size_t buffer_size, upload_handler callback, void *callback_data) {
   /// Load a file - this function is called from javascript when the file upload is activated
-
-  /// The file was not uploaded.
-  /// We must process this case separately because std::string_view(nullptr, 0) results in UB.
-  /// <The behavior is undefined if [s, s + count) is not a valid range
-  /// (even though the constructor may not access any of the elements of this range)>
-  /// https://en.cppreference.com/w/cpp/string/basic_string_view/basic_string_view
-  if (! buffer || buffer_size == 0) {
-    callback(filename, mime_type, std::string_view(), callback_data);
-    return 1;
-  }
-  /// Ok
-  callback(filename, mime_type, {buffer, buffer_size}, callback_data);
+  callback(filename, mime_type, buffer_unique_ptr(buffer), buffer_size, callback_data);
   return 1;
 }
 


### PR DESCRIPTION
Previously, this library would call `_free` immediately after the user callback, meaning that, if the callback cached the buffer `string_view` instead of copying its contents, then the user's code would fall victim to use-after-free bugs. This is what occurred with my project.

I could have avoided this by copying the data pointed to by the `string_view`, but this is inefficient: it would have been better if I could prevent the buffer from being freed until I no longer needed it.

To achieve this, I have made this library wrap the buffer in a `unique_ptr`, and then pass it (via `std::move`) to the user
callback. If the user does nothing with the `unique_ptr`, then the buffer will be automatically freed when the callback ends. If the user tries to copy the `unique_ptr`, an error will be raised at build-time. If the user moves the `unique_ptr`, then the buffer will not be freed when the callback ends, instead being freed whenever the user's moved copy is destroyed. This gives the user full control over the lifetime of the buffer, without allowing it to accidentally leak.

This does change `upload_handler`'s function signature, but it should not be difficult for users to update to it.

I also fixed the callback data example in the readme.